### PR TITLE
Upgrade supervisor to 4.0.1 to support Python3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,4 +4,4 @@ supervisord_nodaemon: 'false'
 supervisord_stdout_enabled: no
 supervisord_stdout_path: '/usr/local/bin/supervisor_stdout'
 supervisord_stdout_version: 0.1.1
-supervisord_version: 3.3.1
+supervisord_version: 4.0.1

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,7 @@
 ---
 - name: supervisord restart
-  service: name=supervisord state=restarted
+  service:
+    name=supervisord
+    state=restarted
+    sleep=5
+  when: ansible_virtualization_type != 'docker'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,5 +3,4 @@
   service:
     name=supervisord
     state=restarted
-    sleep=5
   when: ansible_virtualization_type != 'docker'

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -7,6 +7,7 @@
     executable: '{{ executable_pip }}'
   environment:
     PATH: /usr/local/bin:/usr/bin:{{ ansible_env.PATH }}
+  notify: supervisord restart
 
 - name: Install supervisord stdout
   pip:


### PR DESCRIPTION
## Summary of changes

- Upgrade supervisor to 4.0.1 to support Python3

## How to Test

- `$ cd tests/`
- `$ vagrant up`
- `$ vagrant ssh`
- `$ supervisord -v` see version is `4.0.1`
- `$ sudo supervisorctl status` see services started