### PR TITLE
Make ready for Amazon Linux 2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 supervisord_config_dir: '/etc/supervisor.d'
+supervisord_exec_prefix: '/usr/local'
 supervisord_nodaemon: 'false'
 supervisord_stdout_enabled: no
 supervisord_stdout_path: '/usr/local/bin/supervisor_stdout'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,9 +9,9 @@
     mode: 0755
 
 - name: copy init script for supervisord
-  copy:
-    src: supervisord.sh
-    dest: /etc/init.d/supervisord
+  template:
+    src: 'templates/supervisord.j2'
+    dest: '/etc/init.d/supervisord'
     owner: root
     group: root
     mode: 0755
@@ -19,8 +19,14 @@
 - name: ensure supervisord start on boot
   service: name=supervisord state=started enabled=yes
 
+- name: check if supervisorctl executable exists
+  stat:
+    path: '/usr/local/bin/supervisorctl'
+  register: supervisorctl_executable
+
 - name: make supervisorctl available on the path
   alternatives:
     name: supervisorctl
     link: /usr/bin/supervisorctl
     path: /usr/local/bin/supervisorctl
+  when: supervisorctl_executable.stat.exists

--- a/templates/supervisord.j2
+++ b/templates/supervisord.j2
@@ -16,8 +16,7 @@
 
 prog="supervisord"
 
-prefix="/usr/local"
-exec_prefix="${prefix}"
+exec_prefix="{{ supervisord_exec_prefix }}"
 prog_bin="${exec_prefix}/bin/supervisord"
 prog_ctl="${exec_prefix}/bin/supervisorctl"
 config_file="/etc/supervisord.conf"

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.provider :docker do |docker|
-    docker.image = 'juwaicom/amazonlinux-vagrant:1.0'
+    docker.image = 'juwaicom/amazonlinux-vagrant:2.0'
     docker.force_host_vm = false
     docker.has_ssh = true
     docker.ports = [


### PR DESCRIPTION
## Summary of changes

- Add configuration item for executable location (/usr vs /usr/local)
- Avoid error when executable already at /usr/bin/supervisorctl
- Use Amazon Linux 2 in test

## How to Test

1. Go to tests/ folder
2. Run: `$ vagrant up`
3. See no error