### PR TITLE
Don't store pid/sock/log under /tmp

### DIFF
--- a/templates/supervisord.conf.j2
+++ b/templates/supervisord.conf.j2
@@ -9,23 +9,23 @@
 ;  - Comments must have a leading space: "a=b ;comment" not "a=b;comment".
 
 [unix_http_server]
-file=/tmp/supervisor.sock   ; (the path to the socket file)
-;chmod=0700                 ; socket file mode (default 0700)
-;chown=nobody:nogroup       ; socket file uid:gid owner
-;username=user              ; (default is no username (open server))
-;password=123               ; (default is no password (open server))
+file=/var/run/supervisor.sock       ; (the path to the socket file)
+;chmod=0700                         ; socket file mode (default 0700)
+;chown=nobody:nogroup               ; socket file uid:gid owner
+;username=user                      ; (default is no username (open server))
+;password=123                       ; (default is no password (open server))
 
-;[inet_http_server]         ; inet (TCP) server disabled by default
-;port=127.0.0.1:9001        ; (ip_address:port specifier, *:port for all iface)
-;username=user              ; (default is no username (open server))
-;password=123               ; (default is no password (open server))
+;[inet_http_server]                 ; inet (TCP) server disabled by default
+;port=127.0.0.1:9001                ; (ip_address:port specifier, *:port for all iface)
+;username=user                      ; (default is no username (open server))
+;password=123                       ; (default is no password (open server))
 
 [supervisord]
-logfile=/tmp/supervisord.log        ; (main log file;default $CWD/supervisord.log)
+logfile=/var/log/supervisord.log    ; (main log file;default $CWD/supervisord.log)
 logfile_maxbytes=50MB               ; (max main logfile bytes b4 rotation;default 50MB)
 logfile_backups=10                  ; (num of main logfile rotation backups;default 10)
 loglevel=info                       ; (log level;default info; others: debug,warn,trace)
-pidfile=/tmp/supervisord.pid        ; (supervisord pidfile;default supervisord.pid)
+pidfile=/var/run/supervisord.pid    ; (supervisord pidfile;default supervisord.pid)
 nodaemon={{ supervisord_nodaemon }} ; (start in foreground if true;default false)
 minfds=1024                         ; (min. avail startup file descriptors;default 1024)
 minprocs=200                        ; (min. avail process descriptors;default 200)
@@ -45,7 +45,7 @@ minprocs=200                        ; (min. avail process descriptors;default 20
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
 ;serverurl=http://127.0.0.1:9001 ; use an http:// url to specify an inet socket
 ;username=chris              ; should be same as http_username if set
 ;password=123                ; should be same as http_password if set


### PR DESCRIPTION
## Summary of changes

It seems Amazon Linux 2 will clear tmp folder on regular basis. Need to put the files somewhere more permanent.

## How to Test

```bash
$ cd tests/
$ vagrant up
```