### PR TITLE
Fix sock file location in init script

### DIFF
--- a/templates/supervisord.j2
+++ b/templates/supervisord.j2
@@ -20,7 +20,7 @@ exec_prefix="{{ supervisord_exec_prefix }}"
 prog_bin="${exec_prefix}/bin/supervisord"
 prog_ctl="${exec_prefix}/bin/supervisorctl"
 config_file="/etc/supervisord.conf"
-sock_file="/tmp/supervisor.sock"
+sock_file="/var/run/supervisor.sock"
 
 start()
 {


### PR DESCRIPTION
## Summary of changes

Moved sock file in [previous PR](https://github.com/juwai/ansible-role-supervisor/pull/9). But forgot to update the init script.

## How to Test

```bash
$ cd tests/
$ vagrant up
```